### PR TITLE
CONTRIBUTING: Add Diamond Bluff contribution steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+Diamond Bluff uses GitHub to manage reviews of pull requests.
+
+* If you are a new contributor see: [Steps to Contribute](#steps-to-contribute)
+
+* If you have a trivial fix or improvement, go ahead and create a pull request,
+  addressing (with `@...`) a suitable maintainer of this repository (see
+  [MAINTAINERS.md](MAINTAINERS.md)) in the description of the pull request.
+
+* Be sure to sign off on the [DCO](https://github.com/probot/dco#how-it-works).
+
+## Steps to Contribute
+
+Should you wish to work on an issue, please claim it first by commenting on the
+GitHub issue that you want to work on it. This is to prevent duplicated efforts
+from contributors on the same issue.
+
+## Pull Request Checklist
+
+* Branch from the main branch and, if needed, rebase to the current main branch
+  before submitting your pull request. If it doesn't merge cleanly with main
+  you may be asked to rebase your changes.
+
+* Commits should be as small as possible, while ensuring that each commit is
+  correct independently (i.e., each commit should compile and pass tests).
+
+* If your patch is not getting reviewed or you need a specific person to review
+  it, you can @-reply a reviewer asking for a review in the pull request or a
+  comment. The project will soon have an IRC and/or Slack channel setup, which
+  will also become a useful way to notify a maintainer.
+
+* Add tests relevant to the fixed bug or new feature.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,9 @@
+An alphabetical list of maintainers for Diamond Bluff by last name:
+
+* [Yan Fisher](https://github.com/yanfisher)
+* [Kyle Mestery](https://github.com/mestery)
+* [Tim Michels](https://github.com/timmichels)
+* [Joel Moses](https://github.com/joelmoses)
+* [Kris Murphy](https://github.com/krmurph)
+* [Paul Pindell](https://github.com/pdp2shirts)
+* [Steven Royer](https://github.com/seroyer)


### PR DESCRIPTION
A first crack at adding how to contribute to the Diamond Bluff project.
This is very basic at the moment, with the key concept being mentioning
the [DCO](https://developercertificate.org), which is required for all
commits into the Diamond Bluff repository.

The second thing this commit does is a first crack at setting up a
MAINTAINERS.md file. I've taken this from the list of people in the
Diamond Bluff github project, and whittled it down to people who have
attended meetings regularly. We'll want to trim this back even further
at some point.

Signed-off-by: Kyle Mestery <mestery@mestery.com>