### PR TITLE
governance: Add GOVERNANCE.md document

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,125 @@
+# Diamond Bluff
+
+For an idea of what the goals of the Diamond Bluff project are, please see the
+[high level overview document](README.md).
+
+## Governance
+
+### Governance Goals
+
+The goal of governance for the Diamond Bluff project is to maintain and
+emphasize a technical meritocracy of contributors. Those who contribute the
+most and the best technical solutions, while supporting all contirbutors, have
+the most influence in the technical direction of the project. At the same
+time, a [Board of Directors](#Board of Directors) is established with it's
+own set of responsibilities, to help manage the Diamond Bluff project.
+
+## Membership
+
+The Diamond Bluff project is composed of Platinum, Silver, and Participating
+Academic members. All Platinum and Silver members must be current corporate
+members of the hosting foundation (e.g. Linux Foundation or Open Infrastructure
+Foundation) at any level to participate in the Diamond Bluff project.
+
+Platinum, Silver and Participating Academic Members shal be entitled to:
+
+* Participate in the Diamond Bluff Project memtings, initiatives, events and
+  any other activities.
+* Identify their company as a member or participant in the Diamond Bluff
+  project.
+* Platinum members shall be entitled to appoint a representative to the
+  Board of Directors of the Diamond Bluff project, as well as any future
+  committees established by the Board of Directors.
+
+## Structure
+
+At a high level, the Diamond Bluff project is governed by two main bodies which
+work together to achieve the project's goals:
+
+* A Board of Directors
+* A Technical Steering Committee
+
+### Board of Directors
+
+The Diamond Bluff project Board of Directors shall be composed as follows:
+
+* One representative from each Platinum member.
+* One Silver member representative elected annually by the Silver members for
+  every 5 Silver members, with at least one representative, and no more than 3.
+
+The Board of Directors shall have the following responsibilities:
+
+* Approve a budget directing the use of funds raised from all sources of
+  revenue.
+* Elect a Chair of the Diamond Bluff project to preside over meetings,
+  authorize expenditures approved by the budget and manage any day-to-day
+  operations, and vote on decisions or matters before the Board of Directors.
+
+The Board of Directors shall::
+
+* Demonstrate plans and the means to coordinate with the open source project’s
+  developer community, including on topics such as branding, logos, and other
+  collateral that will represent the community.
+* Engage in a professional manner consistent with maintaining a cohesive
+  community, while also maintaining the goodwill and esteem of the foundation
+  the Diamond Bluff Project is a member of, in the open source software
+  community.
+* Respect the rights of all trademark owners, including any branding and usage
+  guidelines.
+* Engage the foundation the project is a member of for all press and analyst
+  relations activities.
+* Upon request, provide information regarding project participation, including
+  information regarding attendance at project-sponsored events, to the
+  foundation the project is a member of.
+* Engage foundation the project is a member of for any websites directly for
+  the Diamond Buff Project; and operate under such rules and procedures as may
+  from time to time be approved by the Diamond Bluff Board of Directors and
+  confirmed by foundation the project is a part of.
+
+### Technical Steering Committee
+
+The Diamond Bluff Technical Steering Committee shall be composed as follows:
+
+* One appointed representative from each Platinum member
+* A maintainer from each Diamond Bluff sub-project
+
+In addition, anyone can particiapte on the Technical Steering Committee by
+contributing to the technical community and becoming a maintainer of a
+sub-project.
+
+The responsibilities of the Diamond Bluff Technical Steering Committee are
+as follows:
+
+* Coordinating the technical direction of the Diamond Bluff Project
+* In coordination with the Board of Directors, pproving new sub-projects for
+  creation under the Diamond Bluff organization.
+* Helping to identify maintainers of sub-projects, and ensure they have the
+  technical support necessary to be successful in their role as a maintainer.
+* Communicating with external and industry organizations concering Diamond
+  Bluff technical matters.
+* Appointing represenatives to work with other open source or open standards
+  communities.
+* Voting on technical matters relating to the code base of all sub-projects.
+
+## Voting
+
+While is the goal of the project to strive for consensus as a community, if any
+decision requires a vote to move forward, the Board of Directors members shall
+be entitled to vote on a one vote per representative basis.
+Decisions by vote shall be based on a majority vote only when sixty percent
+(60$) of the Board of Directors representatives are either present or
+particiapting electronically. In the event of a tied vote, the Chair shall be
+entitiled to submit a tie-breaking vote
+
+## Budget
+
+The Board of Directors shall approve an annual budget and never commit to spend
+in excess of funds raised. The budget shall be consisten with the non-profit
+mission of the foundation Diamond Bluff is a part of. The foundation shall
+provide regular reports of spend levels against the budget.
+
+## Amendments
+This governiing document may be amended by a super majority vote of all Board
+of Director members, subject to approval by foundation the project is a part
+of. A super majority vote is defined as a vote in favor by 70% of the
+Board of Directors, ignoring any abstentions.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -56,7 +56,7 @@ The Board of Directors shall have the following responsibilities:
   authorize expenditures approved by the budget, and manage any day-to-day
   operations, and vote on decisions or matters before the Board of Directors.
 
-The Board of Directors shall::
+The Board of Directors shall:
 
 * Demonstrate plans and the means to coordinate with the open source project’s
   developer community, including on topics such as branding, logos, and other
@@ -84,13 +84,13 @@ one or more parties as appropriate and necessary, under terms set by the Board.
 Members of the Diamond Bluff Technical Steering Committee (TSC) decide
 technical matters that affect the entire project, administer joint
 project-wide technical resources, and act as a final arbiter of technical
-matters that are not decided inside individual subprojects.
+matters that are not decided inside individual sub-projects.
 
 #### TSC Membership
 
 All TSC members must be currently contributing engineers, documentation
 writers, test platform adminstrators, specification editors, or other direct
-technical contributors to one or more subprojects. TSC members need not be
+technical contributors to one or more sub-projects. TSC members need not be
 employees of sponsoring organizations.
 
 During the first year of of the project, The TSC shall be composed as follows:
@@ -105,7 +105,7 @@ composition will become:
 * Two technical contributors appointed by the Board
 
 Membership in the TSC will gradually transition to a model of elected
-subproject technical leadership, starting in the second year of the project.
+sub-project technical leadership, starting in the second year of the project.
 Details for this transition will be decided by the Board.
 
 Starting in the second year of the project, no individual may hold a seat on
@@ -138,8 +138,8 @@ as follows:
   testing infrastructure.
 * Acting as "court of final appeal" for technical matters which are not
   resolved through normal decision mechanisms within the individual
-  subprojects.
-* Coordinating response to security issues and ensuring that all subprojects
+  sub-projects.
+* Coordinating response to security issues and ensuring that all sub-projects
   are reasonably secure.
 
 For any of the above responsibilities, the TSC may delegate their powers to one

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -45,7 +45,8 @@ The Diamond Bluff project Board of Directors shall be composed as follows:
 
 * One representative from each Platinum member.
 * One Silver member representative elected annually by the Silver members for
-  every 5 Silver members, with at least one representative, and no more than 3.
+  every 5 (or fraction thereof) Silver members, with at least one
+  representative, and no more than 3.
 
 The Board of Directors shall have the following responsibilities:
 
@@ -75,30 +76,95 @@ The Board of Directors shall::
   by the Diamond Bluff Board of Directors and confirmed by the project's
   foundation.
 
+For any of the above responsibilities, the Board may delegate their powers to
+one or more parties as appropriate and necessary, under terms set by the Board.
+
 ### Technical Steering Committee
 
-The Diamond Bluff Technical Steering Committee shall be composed as follows:
+Members of the Diamond Bluff Technical Steering Committee (TSC) decide
+technical matters that affect the entire project, administer joint
+project-wide technical resources, and act as a final arbiter of technical
+matters that are not decided inside individual subprojects.
+
+#### TSC Membership
+
+All TSC members must be currently contributing engineers, documentation
+writers, test platform adminstrators, specification editors, or other direct
+technical contributors to one or more subprojects. TSC members need not be
+employees of sponsoring organizations.
+
+During the first year of of the project, The TSC shall be composed as follows:
 
 * One appointed representative from each Platinum member
-* A maintainer from each Diamond Bluff sub-project
+* One maintainer from each Diamond Bluff sub-project, selected by the Board
 
-In addition, anyone can participate on the Technical Steering Committee by
-contributing to the technical community and becoming a maintainer of a
-sub-project.
+Starting one year after the launch of the Diamond Bluff governance, the TSC
+composition will become:
+
+* Two maintainers from each Diamond Bluff sub-project
+* Two technical contributors appointed by the Board
+
+Membership in the TSC will gradually transition to a model of elected
+subproject technical leadership, starting in the second year of the project.
+Details for this transition will be decided by the Board.
+
+Starting in the second year of the project, no individual may hold a seat on
+the Board and the TSC at the same time. No more than 40% of TSC members may be
+employed by the same organization.
+
+Should any TSC member cease regular technical contributions, their membership
+will terminate at the next regular annual selection date. If a TSC member
+violates the Code of Conduct, they may be removed from the TSC by the Code of
+Conduct Committee.
+
+#### TSC Responsibilities
 
 The responsibilities of the Diamond Bluff Technical Steering Committee are
 as follows:
 
 * Coordinating the technical direction of the Diamond Bluff Project
-* In coordination with the Board of Directors, approving new sub-projects for
-  creation under the Diamond Bluff organization.
-* Helping to identify maintainers of sub-projects, and ensure they have the
-  technical support necessary to be successful in their role as a maintainer.
+* Nominating and reviewing new sub-projects for creation under the Diamond
+  Bluff organization after final approval by the Board.
+* Confirming selected maintainers in the sub-projects, and ensuring they have
+  the technical support necessary to be successful in their role as a
+  maintainer.
 * Communicating with external and industry organizations concering Diamond
   Bluff technical matters.
 * Appointing represenatives to work with other open source or open standards
   communities.
-* Voting on technical matters relating to the code base of all sub-projects.
+* Voting on technical matters relating to any common code base or
+  specifications affecting all sub-projects.
+* Adminstering common technical resources, such as repository hosting and the
+  testing infrastructure.
+* Acting as "court of final appeal" for technical matters which are not
+  resolved through normal decision mechanisms within the individual
+  subprojects.
+* Coordinating response to security issues and ensuring that all subprojects
+  are reasonably secure.
+
+For any of the above responsibilities, the TSC may delegate their powers to one
+or more parties as appropriate and necessary, under terms set by the TSC.
+
+#### TSC Meetings
+
+The TSC shall hold one or more public meetings each month. All contributors
+to, or sponsors of, Diamond Bluff shall be entitled to attend these meetings.
+Public meetings will have a public agenda to which members of the community may
+reasonably add items.
+
+The TSC may also have private meetings from time to time, particularly when
+discussing security response or settling escalated disputes. All TSC members
+will be included in private meetings.
+
+### Code of Conduct Committee
+
+The Board will appoint or elect three or more individuals to serve as a Code of
+Conduct Committee (COCC). Committee members may also be members of the Board or
+the TSC, or they may be outside parties (paid or unpaid) with expertise in code
+of conduct (CoC) enforcement, or just members of the community. The CoCC should
+be selected to represent the diversity of the community.
+
+The CoCC will establish fair and standard processes for handling reports of violations of the CoC, as well as a system of remedies, in order to protect the well-being of the project. The CoCC will recommend the appropriate resolution to the Board, up to and including the removal of any individual from participation, either temporarily or permanently. Should a member of the CoCC itself be accused of a violation, that accusation will be handled by an individual appointed by the foundation.
 
 ## Voting
 
@@ -109,6 +175,8 @@ Decisions by vote shall be based on a majority vote only when sixty percent
 (>= 60$) or greater of the Board of Directors representatives are either
 present or particiapting electronically. In the event of a tied vote, the Chair
 shall be entitiled to submit a tie-breaking vote
+All elections shall be held using an online preference election mechanism to be
+selected and approved by the Board.
 
 ## Budget
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -168,15 +168,15 @@ The CoCC will establish fair and standard processes for handling reports of viol
 
 ## Voting
 
-While is the goal of the project to strive for consensus as a community, if any
-decision requires a vote to move forward, the Board of Directors members shall
-be entitled to vote on a one vote per representative basis.
-Decisions by vote shall be based on a majority vote only when sixty percent
-(>= 60$) or greater of the Board of Directors representatives are either
-present or particiapting electronically. In the event of a tied vote, the Chair
-shall be entitiled to submit a tie-breaking vote
-All elections shall be held using an online preference election mechanism to be
-selected and approved by the Board.
+While it is the goal of the project to strive for consensus as a community, if
+any decision requires a vote to move forward, either the Board of Directors
+members or the Technical Steering Committee members shall be entitled to vote
+on a one vote per representative basis. Decisions by vote shall be based on a
+majority vote only when sixty percent (>= 60$) or greater of the voting body
+representatives are either present or particiapting electronically. In the
+event of a tied vote, the Chair shall be entitiled to submit a tie-breaking
+vote. All elections shall be held using an online preference election mechanism
+to be selected and approved by the Board.
 
 ## Budget
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -21,12 +21,12 @@ Academic members. All Platinum and Silver members must be current corporate
 members of the hosting foundation (e.g. Linux Foundation or Open Infrastructure
 Foundation) at any level to participate in the Diamond Bluff project.
 
-Platinum, Silver and Participating Academic Members shal be entitled to:
+Platinum, Silver and Participating Academic Members shall be entitled to:
 
 * Participate in the Diamond Bluff Project memtings, initiatives, events and
   any other activities.
-* Identify their company as a member or participant in the Diamond Bluff
-  project.
+* Identify their company or academic institution as a member or participant in
+  the Diamond Bluff project.
 * Platinum members shall be entitled to appoint a representative to the
   Board of Directors of the Diamond Bluff project, as well as any future
   committees established by the Board of Directors.
@@ -52,7 +52,7 @@ The Board of Directors shall have the following responsibilities:
 * Approve a budget directing the use of funds raised from all sources of
   revenue.
 * Elect a Chair of the Diamond Bluff project to preside over meetings,
-  authorize expenditures approved by the budget and manage any day-to-day
+  authorize expenditures approved by the budget, and manage any day-to-day
   operations, and vote on decisions or matters before the Board of Directors.
 
 The Board of Directors shall::
@@ -61,20 +61,19 @@ The Board of Directors shall::
   developer community, including on topics such as branding, logos, and other
   collateral that will represent the community.
 * Engage in a professional manner consistent with maintaining a cohesive
-  community, while also maintaining the goodwill and esteem of the foundation
-  the Diamond Bluff Project is a member of, in the open source software
+  community, while also maintaining the goodwill and esteem of the project's
+  foundation, in the open source software community.
   community.
 * Respect the rights of all trademark owners, including any branding and usage
   guidelines.
-* Engage the foundation the project is a member of for all press and analyst
-  relations activities.
+* Engage the project's foundation for all press and analyst relations activities.
 * Upon request, provide information regarding project participation, including
   information regarding attendance at project-sponsored events, to the
-  foundation the project is a member of.
-* Engage foundation the project is a member of for any websites directly for
-  the Diamond Buff Project; and operate under such rules and procedures as may
-  from time to time be approved by the Diamond Bluff Board of Directors and
-  confirmed by foundation the project is a part of.
+  project's foundation.
+* Engage the project's foundation for any Diamond Bluff project websites, and
+  operate under such rules and procedures as may from time to time be approved
+  by the Diamond Bluff Board of Directors and confirmed by the project's
+  foundation.
 
 ### Technical Steering Committee
 
@@ -83,7 +82,7 @@ The Diamond Bluff Technical Steering Committee shall be composed as follows:
 * One appointed representative from each Platinum member
 * A maintainer from each Diamond Bluff sub-project
 
-In addition, anyone can particiapte on the Technical Steering Committee by
+In addition, anyone can participate on the Technical Steering Committee by
 contributing to the technical community and becoming a maintainer of a
 sub-project.
 
@@ -91,7 +90,7 @@ The responsibilities of the Diamond Bluff Technical Steering Committee are
 as follows:
 
 * Coordinating the technical direction of the Diamond Bluff Project
-* In coordination with the Board of Directors, pproving new sub-projects for
+* In coordination with the Board of Directors, approving new sub-projects for
   creation under the Diamond Bluff organization.
 * Helping to identify maintainers of sub-projects, and ensure they have the
   technical support necessary to be successful in their role as a maintainer.
@@ -107,19 +106,19 @@ While is the goal of the project to strive for consensus as a community, if any
 decision requires a vote to move forward, the Board of Directors members shall
 be entitled to vote on a one vote per representative basis.
 Decisions by vote shall be based on a majority vote only when sixty percent
-(60$) of the Board of Directors representatives are either present or
-particiapting electronically. In the event of a tied vote, the Chair shall be
-entitiled to submit a tie-breaking vote
+(>= 60$) or greater of the Board of Directors representatives are either
+present or particiapting electronically. In the event of a tied vote, the Chair
+shall be entitiled to submit a tie-breaking vote
 
 ## Budget
 
 The Board of Directors shall approve an annual budget and never commit to spend
-in excess of funds raised. The budget shall be consisten with the non-profit
-mission of the foundation Diamond Bluff is a part of. The foundation shall
-provide regular reports of spend levels against the budget.
+in excess of funds raised. The budget shall be consistent with the non-profit
+mission of the Diamond Bluff project's foundation. The foundation shall provide
+regular reports of spend levels against the budget.
 
 ## Amendments
 This governiing document may be amended by a super majority vote of all Board
 of Director members, subject to approval by foundation the project is a part
-of. A super majority vote is defined as a vote in favor by 70% of the
+of. A super majority vote is defined as a vote in favor by 70% or great of the
 Board of Directors, ignoring any abstentions.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -23,7 +23,7 @@ Foundation) at any level to participate in the Diamond Bluff project.
 
 Platinum, Silver and Participating Academic Members shall be entitled to:
 
-* Participate in the Diamond Bluff Project memtings, initiatives, events and
+* Participate in the Diamond Bluff Project meetings, initiatives, events and
   any other activities.
 * Identify their company or academic institution as a member or participant in
   the Diamond Bluff project.


### PR DESCRIPTION
This commit adds an initial stab at a Diamond Bluff governance
structure. This includes both a Board of Directors, as well as a
Technical Steering Commmittee.

Signed-off-by: Kyle Mestery <mestery@mestery.com>