### PR TITLE
maintainers: Update maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,7 +2,6 @@ An alphabetical list of maintainers for Diamond Bluff by last name:
 
 * [Yan Fisher](https://github.com/yanfisher)
 * [Kyle Mestery](https://github.com/mestery)
-* [Tim Michels](https://github.com/timmichels)
 * [Joel Moses](https://github.com/joelmoses)
 * [Kris Murphy](https://github.com/krmurph)
 * [Paul Pindell](https://github.com/pdp2shirts)


### PR DESCRIPTION
Remove Tim Michels as a maintainer. He's moving to a member role.

Signed-off-by: Kyle Mestery <mestery@mestery.com>