### PR TITLE
Update MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,7 +1,8 @@
 An alphabetical list of maintainers for Diamond Bluff by last name:
 
+* [Boris Glimcher](https://github.com/glimchb)
 * [Kyle Mestery](https://github.com/mestery)
-* [Joel Moses](https://github.com/joelmoses)
 * [Kris Murphy](https://github.com/krmurph)
 * [Paul Pindell](https://github.com/pdp2shirts)
 * [Steven Royer](https://github.com/seroyer)
+* [Mark Sanders](https://github.com/sandersms)


### PR DESCRIPTION
Remove Joel. He has no commits in this repository and doesn't respond to
slack messages, so I don't think he should be a maintainer.

Add Mark and Boris, who each run separate sub-groups and have been
making commmits to their respective git repositories.

Signed-off-by: Kyle Mestery <mestery@mestery.com>